### PR TITLE
fix uninitialized pointers in Linux openAllSpectrometers

### DIFF
--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -13,6 +13,18 @@ sharing the basic source tree straightforward.
 
 - libusb-1.0
 
+## udev
+
+To access Wasatch spectrometers from "userland" on Linux (without running with 
+sudo or root privs), you need to "grant user access" to our devices by installing
+the following file:
+
+    $ cd Wasatch.VCPP
+    $ sudo cp udev/10-wasatch.rules /etc/udev/rules.d
+
+After installing the file, you need to restart or "HUP" udev (simplest method is
+just to reboot the computer).
+
 # Building
 
     $ cd Wasatch.VCPP

--- a/WasatchVCPPLib/WasatchVCPPLib/Driver.cpp
+++ b/WasatchVCPPLib/WasatchVCPPLib/Driver.cpp
@@ -138,7 +138,7 @@ int WasatchVCPP::Driver::openAllSpectrometers()
         }
     }
 #else
-    libusb_device **devs;
+    libusb_device **devs = nullptr;
     int r = libusb_init(nullptr);
 
     if (r < 0) 
@@ -148,14 +148,14 @@ int WasatchVCPP::Driver::openAllSpectrometers()
     }
 
     ssize_t cnt = libusb_get_device_list(nullptr, &devs);
-
-    if (cnt < 0){
+    if (cnt < 0)
+    {
         logger.debug("Failed to get USB device list");
         libusb_exit(nullptr);
         return int(cnt);
     }
 
-    libusb_device *dev;
+    libusb_device *dev = nullptr;
     int i = 0;
 
     while ((dev = devs[i++]) != nullptr)
@@ -176,10 +176,10 @@ int WasatchVCPP::Driver::openAllSpectrometers()
             {
                 logger.debug("opening device");
 
-                libusb_device_handle *udev;
+                libusb_device_handle *udev = nullptr;
                 int openResult = libusb_open(dev, &udev);
 
-                if(udev != nullptr)
+                if (udev != nullptr)
                 {
                     if (desc.bNumConfigurations)
                     {

--- a/udev/10-wasatch.rules
+++ b/udev/10-wasatch.rules
@@ -4,15 +4,12 @@
 SUBSYSTEM!="usb_device", ACTION!="add", GOTO="wasatch_rules_end"
 
 # Stroker USB Board FX2 Code
-ATTRS{idVendor}=="24aa", ATTRS{idProduct}=="1000", SYMLINK+="stroker-fx2-%n", MODE:="0666"
+ATTRS{idVendor}=="24aa", ATTRS{idProduct}=="1000", SYMLINK+="wasatch-fx2-%n", MODE:="0666"
 
 # Hamamatsu InGaAs USB Board FX2 Code
-ATTRS{idVendor}=="24aa", ATTRS{idProduct}=="2000", SYMLINK+="stroker-ingaas-%n", MODE:="0666"
-
-# Dragster USB Board FX3 Code
-ATTRS{idVendor}=="24aa", ATTRS{idProduct}=="3000", SYMLINK+="dragster-%n", MODE:="0666"
+ATTRS{idVendor}=="24aa", ATTRS{idProduct}=="2000", SYMLINK+="wasatch-ingaas-%n", MODE:="0666"
 
 # Stroker ARM USB Board
-ATTRS{idVendor}=="24aa", ATTRS{idProduct}=="4000", SYMLINK+="stroker-arm-%n", MODE:="0666"
+ATTRS{idVendor}=="24aa", ATTRS{idProduct}=="4000", SYMLINK+="wasatch-arm-%n", MODE:="0666"
 
 LABEL="wasatch_rules_end"


### PR DESCRIPTION
* fix uninitialized pointers in Linux openAllSpectrometers when udev file missing/unused
* update symlink labels in rules file to current nomenclature (deprecate legacy PID)
* update Linux README to include udev setup